### PR TITLE
Suppress livereload for 0-byte files

### DIFF
--- a/bin/serveur
+++ b/bin/serveur
@@ -167,6 +167,7 @@ if (program.livereload) {
   var lrServer = new LiveReloadServer();
   lrServer.listen(port);
   gaze(path + '/**/*', function(){
+    if (fs.statSync(filepath).size === 0) return;
     this.on('all', function(event, filepath){
       lrServer.changed({
         body: {


### PR DESCRIPTION
If you're going to use the shell `>` operator to make files, like so:

``` sh
$ serveur -R public
serving /Users/rsc/public on port 3000

# elsewhere...
$ browserify app.js > public/app.js
```

...serveur will choke because this will actually first write _0_ bytes to `public/app.js`, then write the full contents a few moments later. This will make livereload work on the _0_ byte file, leading to strange results.

This fix will ensure that livereload is suppressed for _0_ byte files.
