### PR TITLE
Fix statSync error on livereload

### DIFF
--- a/bin/serveur
+++ b/bin/serveur
@@ -167,8 +167,8 @@ if (program.livereload) {
   var lrServer = new LiveReloadServer();
   lrServer.listen(port);
   gaze(path + '/**/*', function(){
-    if (fs.statSync(filepath).size === 0) return;
     this.on('all', function(event, filepath){
+      if (fs.statSync(filepath).size === 0) return;
       lrServer.changed({
         body: {
           files: escape(filepath)


### PR DESCRIPTION
Oops! I pasted it in the wrong line... this should fix the `filepath is undefined` error from happening.
